### PR TITLE
add wercker.yml including test,build,deploy step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@
 .cache
 
 dist
-build
 node_modules
 tarumae-*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,6 @@
+.cache
+build
+node_modules
 resources
-
+src
+wercker.yml

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ To build a minified output:
 npm run build
 ```
 
+## Build release package
+
+```
+build/pack
+```
+
+
 # Use Tarumae-Viewer
 
 ## Hello World

--- a/build/pack
+++ b/build/pack
@@ -1,0 +1,5 @@
+mkdir -p dist
+rm -rf dist/*
+npm run pub
+npm pack | xargs -I@ mv @ dist/
+rm -rf dist/js

--- a/build/version.js
+++ b/build/version.js
@@ -1,0 +1,16 @@
+TarumaeRenderer = {};
+
+require("../src/js/ver.js");
+
+var version = TarumaeRenderer.Version;
+
+if (process.argv.includes('--major')) {
+  console.log( version.major );
+}
+else if (process.argv.includes('--minor')) {
+  console.log( [version.major, version.minor].join(".") );
+}
+else {
+  console.log( [version.major, version.minor, version.build + version.revision].join(".") );
+}
+

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
 	"main": "./dist/js/tarumae.js",
 	"scripts": {
 		"webpack": "webpack",
+		"test": ":",
 		"dev": "webpack-dev-server",
-		"pub": "npx babel src --out-dir dist"
+		"pub": "npx babel src -d dist"
 	},
 	"keywords": [],
 	"author": "BULB CORP.",

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,104 @@
+#
+# @note please define 'Application environment variables' or 'Pipeline environment variables' on werkcer
+# 
+# @env AWS_ACCESS_KEY_ID      ***
+# @env AWS_SECRET_ACCESS_KEY  ***
+# @env AWS_S3_BUCKET          s3://tarumae-assets/viewer/
+# @env SLACK_SUBDOMAIN        autofloor
+# @env SLACK_TOKEN            ***
+# @env SLACK_CHANNEL          #notifications
+# @env DEPLOY_URL_BASE        https://s3-ap-northeast-1.amazonaws.com/tarumae-assets/viewer/
+#
+box: node:8.9.4
+test:
+  steps:
+    - script:
+      name: echo nodejs information
+      code: |
+        echo "node version $(node -v) running"
+        echo "npm version $(npm -v) running"
+
+    - script:
+      name: install
+      code: |
+        npm install
+
+    - script:
+      name: test
+      code: |
+        npm run test
+
+build:
+  steps:
+    - script:
+      name: echo nodejs information
+      code: |
+        echo "node version $(node -v) running"
+        echo "npm version $(npm -v) running"
+
+    - script:
+      name: install
+      code: |
+        rm -rf node_modules
+        npm install
+
+    - script:
+      name: build
+      code: |
+        npm run pub
+        ls -al ./dist/
+
+deploy:
+  steps:
+    - script:
+      name: echo nodejs information
+      code: |
+        echo "node version $(node -v) running"
+        echo "npm version $(npm -v) running"
+
+    - script:
+      name: install
+      code: |
+        rm -rf node_modules
+        npm install
+
+    - script:
+      name: build
+      code: |
+        build/pack
+
+    - script:
+      name: version
+      code: |
+        export PACKAGE_VERSION=`node build/version.js`
+        export DEPLOY_DIR=$([ $WERCKER_GIT_BRANCH = "master" ] && echo `node build/version.js --minor` || echo $WERCKER_GIT_BRANCH)
+        export AWS_S3_BUCKET_VERSION=$AWS_S3_BUCKET$DEPLOY_DIR'/'
+        # export PACKAGE_LATEST='latest'
+
+    - s3sync:
+      key-id: $AWS_ACCESS_KEY_ID
+      key_secret: $AWS_SECRET_ACCESS_KEY
+      bucket-url: $AWS_S3_BUCKET_VERSION
+      source-dir: dist/
+      delete-removed: false
+      #opts: --acl-private
+
+  after-steps:
+    - script:
+      name: version
+      code: |
+        export PACKAGE_VERSION=`node build/version.js`
+        export DEPLOY_DIR=$([ $WERCKER_GIT_BRANCH = "master" ] && echo `node build/version.js --minor` || echo $WERCKER_GIT_BRANCH)
+        export AWS_S3_BUCKET_VERSION=$AWS_S3_BUCKET$DEPLOY_DIR'/'
+        # export PACKAGE_LATEST='latest'
+
+    - sherzberg/slack-notify:
+      subdomain: $SLACK_SUBDOMAIN
+      token: $SLACK_TOKEN
+      channel: $SLACK_CHANNEL
+      username: "Deployer"
+      icon_emoji: ":robot_face:"
+      passed_message: "*Wercker App* : <$WERCKER_APPLICATION_URL|$WERCKER_APPLICATION_OWNER_NAME/$WERCKER_APPLICATION_NAME>\n
+        *Branch*         : <https://github.com/$WERCKER_GIT_OWNER/$WERCKER_GIT_REPOSITORY/tree/$WERCKER_GIT_BRANCH|$WERCKER_GIT_BRANCH>\n
+        *Pushed by*   : $WERCKER_STARTED_BY\n
+        *Deployed to*: <$DEPLOY_URL_BASE$DEPLOY_DIR/tarumae-$PACKAGE_VERSION.tgz|/$DEPLOY_DIR/tarumae-$PACKAGE_VERSION.tgz>"


### PR DESCRIPTION
- [x] version取得スクリプト作成
    - TODO: package.jsonと２重管理なので気を付ける
- [x] release用ビルドスクリプト作成
    - `npm pack` してdistに移動するだけ
- [x] werkcer.yml追加
    - 全ブランチでtest起動
        - test はダミー
    - developはtest後にbuild（`npm run pub`）
    - masterはdeploy（`build/pack` → s3sync）
- [x] `delete-removed: false`
    - https://github.com/bulbinc/autofloor-editor/pull/14